### PR TITLE
add non-ascii support when creating temp file

### DIFF
--- a/scripts/python/HoudiniExprEditor/ParmWatcher.py
+++ b/scripts/python/HoudiniExprEditor/ParmWatcher.py
@@ -459,8 +459,12 @@ def add_watcher(selection, type_="parm"):
     
         data = selection.script()
 
+    # use uft-8 only when nacessary
     with open(file_path, 'w') as f:
-        f.write(data)
+        try:
+            f.write(data)
+        except UnicodeEncodeError:
+            f.write(data.encode("UTF-8"))
 
     vsc = get_external_editor()
     if not vsc:


### PR DESCRIPTION
simply add utf-8 encoding when nacessary. UI elements some times includes non-ascii chars so could be useful.